### PR TITLE
Add validation example

### DIFF
--- a/static/validation.js
+++ b/static/validation.js
@@ -1,0 +1,114 @@
+function checkValidate(backendUrl, {
+  file,
+  contents,
+  profileContents,
+  profileId,
+  checkTimeoutMS: checkResultsTimeoutMS = 500
+}) {
+
+  let promiseResolve = null;
+  let promiseReject = null;
+  const result = new Promise((resolve, reject) => {
+    promiseResolve = resolve;
+    promiseReject = reject;
+  });
+  let currentTimeout;
+
+  const headers = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+  };
+
+  let jobId = null;
+  let jobStatus = null;
+
+  const execute = async () => {
+    try {
+      const requestData = {
+        inputs: {
+          cityFiles: [
+            {
+              name: "file-0",
+              data_str: contents || await file.text(),
+            },
+          ],
+        },
+      };
+      let actualProfileId = profileId;
+      if (!profileId) {
+        actualProfileId = '_shaclValidation';
+        requestData.inputs.shacl = profileContents;
+      }
+      let response = await fetch(new URL(`processes/${actualProfileId}/execution`, backendUrl), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(requestData),
+      });
+      if (!response.ok) {
+        promiseReject(`Request failed with status ${response.status} - ${response.statusText}`);
+      }
+      let data = await response.json();
+
+      jobId = data.jobID;
+      jobStatus = data.status;
+      if (['accepted', 'running'].includes(data.status)) {
+        currentTimeout = setTimeout(checkJobStatus, checkResultsTimeoutMS);
+      } else if (data.status === 'successful') {
+        fetchResults();
+      } else {
+        promiseReject(`Job submission failed with status ${data.status}`);
+      }
+    } catch (e) {
+      promiseReject(e);
+    }
+  };
+
+  const checkJobStatus = async () => {
+    try {
+      let response = await fetch(new URL(`jobs/${jobId}`, backendUrl), {
+        headers,
+      });
+      if (!response.ok) {
+        promiseReject(`Request failed with status ${response.status} - ${response.statusText}`);
+      }
+      let data = await response.json();
+      jobStatus = data.status;
+      if (['accepted', 'running'].includes(data.status)) {
+        setTimeout(checkJobStatus, checkResultsTimeoutMS);
+      } else {
+        fetchResults();
+      }
+    } catch (e) {
+      promiseReject(e);
+    }
+  };
+
+  const fetchResults = async () => {
+    try {
+      let response = await fetch(new URL(`jobs/${jobId}/results`, backendUrl), {
+        headers,
+      });
+      if (!response.ok) {
+        promiseReject(`Error retrieving job results: ${response.status} - ${response.statusText}`);
+      }
+      try {
+        promiseResolve(await response.json());
+      } catch (e) {
+        promiseReject(await response.text());
+      }
+    } catch (e) {
+      promiseReject(e);
+    }
+  };
+
+  const cancel = () => {
+    clearTimeout(currentTimeout);
+  }
+
+  execute();
+
+  return {
+    cancel,
+    result,
+  };
+}

--- a/templates/validation.html
+++ b/templates/validation.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Validation test</title>
+    <script src="../static/validation.js"></script>
+    <style>
+      .hidden {
+          display: none;
+      }
+      .error {
+          color: red;
+          border-color: red;
+      }
+      textarea {
+          width: 100%;
+          height: 400px;
+          font-family: Consolas, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>Input</h1>
+      <form id="validate-form">
+        <div>
+          <label for="file">File</label>
+          <input type="file" id="file" name="file">
+        </div>
+        <div>
+          <label for="profile"></label>
+          <textarea id="profile" name="profile"></textarea>
+        </div>
+        <div>
+          <button id="submit" type="submit">Validate</button>
+        </div>
+      </form>
+    </div>
+    <div id="results" class="hidden">
+      <h1>Results</h1>
+      <p id="loading" class="hidden">Loading...</p>
+      <textarea readonly id="report"></textarea>
+    </div>
+    <script>
+      const resultsDiv = document.getElementById('results');
+      resultsDiv.classList.add('hidden');
+      const form = document.querySelector('#validate-form');
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        const file = form.file.files?.[0];
+        if (!file) {
+          alert('Please select a file to validate.');
+          return;
+        }
+        const profileText = form.profile.value;
+        if (!profileText?.trim?.()) {
+          alert('Please add content for the profile.');
+          return;
+        }
+        const loader = document.getElementById('loading');
+        const resultsTextArea = document.getElementById('report');
+        loader.classList.remove('hidden');
+        resultsDiv.classList.remove('hidden');
+        resultsTextArea.classList.remove('error');
+        resultsTextArea.classList.add('hidden');
+
+        // Running with file and profile contents.
+        const validation = checkValidate('http://localhost:8080/', {
+          file: file,
+          profileContents: profileText,
+        });
+
+        // .result is a promise that resolves with the validation results.
+        validation.result
+          .then(r => {
+            resultsTextArea.value = JSON.stringify(r, null, 2);
+          })
+          .catch((e) => {
+            resultsTextArea.classList.add('error');
+            resultsTextArea.value = e?.message || e;
+            console.error(e);
+          })
+          .finally(() => {
+            resultsTextArea.classList.remove('hidden');
+            loader.classList.add('hidden');
+          });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
`validation.js` defines a `checkValidate()` method that's called with the following parameters:
* `backendUrl`: URL to the validation service (e.g., http://localhost:8080).
* `options`: Object with:
    * Either `file` or `contents`: CityJSON file. `contents` is a JSON string, while `file` is a file from from an HTML [`<input type="file">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file).
    * Either `profileContents` or `profileId`: `profileContents` is the SHACL contents of the profile, while `profileId` is one of the profile ids supported by the backend.
    * (Optional) `checkTimeoutMS`: Number of milliseconds to wait before calls to check if the job is done (500ms by default).

The return value is an object with:
* `cancel()`: A method that can be used to cancel the validation process.
* `result`: A [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will resolve to the validation results (or throw out an error on fail).

`validation.html` shows an example of how to use `checkValidate()`.